### PR TITLE
Fix mutable default argument bug

### DIFF
--- a/src/test_model.py
+++ b/src/test_model.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+from typing import List, Optional
 import openai
 sys.path.append(os.getcwd())
 import tqdm
@@ -21,7 +22,9 @@ openai.api_key = '''sk-test'''
 openai.api_base = "http://127.0.0.1:8000/v1"
 
 
-def handler_text(content: str, history: [], config):
+def handler_text(content: str, history: Optional[List] = None, config=None):
+    if history is None:
+        history = []
 
     messages = [{"role": "system", "content": f'{config.default_prompt}'}]
     for item in history:

--- a/src/wechat_bot/handler/text.py
+++ b/src/wechat_bot/handler/text.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional
 
 import openai
 
@@ -6,7 +7,9 @@ import openai
 log = logging.getLogger('text')
 
 
-def handler_text(content: str, history: [], config):
+def handler_text(content: str, history: Optional[List] = None, config=None):
+    if history is None:
+        history = []
     # todo 收到/clear清理历史记录
     # try:
     #    history.clear()


### PR DESCRIPTION
## Summary
- avoid shared list between invocations in `handler_text`
- handle optional parameters in tests

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '"')`
- `python -m py_compile WeClone-audio/src/server未完工/handle_text.py WeClone-audio/src/server未完工/server.py WeClone-audio/src/server未完工/tts_handler.py WeClone-audio/src/server未完工/utils.py make_dataset/csv_to_json-单句回答.py make_dataset/csv_to_json-单句多轮.py`
